### PR TITLE
do a little housekeeping

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+public/bootstrap/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    // rules here take precedence over airbnb's
+    "func-names": 0,
+    "strict": [2, "global"],
+    "max-len": [2, 80, 4]
+  },
+  "ecmaFeatures": {
+    "modules": false
+  },
+  "root": true,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+conf/custom-config.yaml
+node_modules/
+stats.db

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Run it via
-`$ ./run.sh`
+`$ npm start`
 
 
 # Installation Notes
@@ -35,4 +35,3 @@ GOTO Common
 
 ## Common
 `$ npm install js-yaml fs express irc async cron jade sqlite3`
-

--- a/conf/custom-config.yaml.dist
+++ b/conf/custom-config.yaml.dist
@@ -19,6 +19,8 @@ config:
     - member1
     - member2
   domain: 'example.com'
+  web:
+    port: 8080
   timers: {
     earlyReminder: '0 45 17 * * 1-5',
     dueReminder: '0 0 19 * * 1-5',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "private": "true",
   "dependencies": {
     "async": "0.2.x",
+    "babel-eslint": "^4.1.2",
     "cron": "1.0.x",
+    "eslint": "^1.4.1",
+    "eslint-config-airbnb": "0.0.8",
+    "eslint-plugin-react": "^3.3.2",
     "express": "3.2.x",
     "irc": "0.3.x",
     "jade": "0.31.x",
@@ -18,7 +22,8 @@
   },
   "scripts": {
     "start": "while(true) do node standupbot.js; sleep 5; done",
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint ."
   },
   "engine": "node >= 0.8.14"
 }

--- a/package.json
+++ b/package.json
@@ -2,21 +2,22 @@
   "name": "standupbot",
   "description": "A bot and small website used for standups",
   "author": "Ele Dev <ele-dev@lists.rackspace.com>",
-  "version" : "0.0.1",
-  "private" : "true",
+  "version": "0.0.1",
+  "private": "true",
   "dependencies": {
-    "js-yaml": "2.0.x",
-    "express": "3.2.x",
-    "irc": "0.3.x",
     "async": "0.2.x",
     "cron": "1.0.x",
+    "express": "3.2.x",
+    "irc": "0.3.x",
     "jade": "0.31.x",
-    "sqlite3": "2.1.x"
+    "js-yaml": "2.0.x",
+    "sqlite3": "^3.1.0"
   },
   "devDependencies": {
     "mocha": "1.10.x"
   },
   "scripts": {
+    "start": "while(true) do node standupbot.js; sleep 5; done",
     "test": "mocha"
   },
   "engine": "node >= 0.8.14"

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-while(true) do node standupbot.js; sleep 5; done

--- a/standupbot.js
+++ b/standupbot.js
@@ -254,5 +254,5 @@ process.on('SIGINT', function() {
 });
 
 // Start the server
-app.listen(8080);
-console.log('Listening on port 8080');
+app.listen(config.web.port);
+console.log('Listening on port ' + config.web.port);


### PR DESCRIPTION
This adds a gitignore, updates sqlite3 to a version that supports node 0.12, adds a webport option, and moves run.sh into `npm start`.
