### PR TITLE
Update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Dependency Status](https://david-dm.org/osuosl/standupbot.svg)](https://david-dm.org/osuosl/standupbot)
+
 Run it via
 `$ npm start`
 

--- a/README.md
+++ b/README.md
@@ -5,35 +5,24 @@ Run it via
 
 
 # Installation Notes
+First install nodejs the normal way for your operating system.
 
+## OS X with Homebrew
 
-## MacOSX
+```
+$ brew install node
+```
 
-`$ brew install node`
+## Ubuntu Linux
 
-`$ brew install npm`
+```
+$ sudo apt-get update
+$sudo apt-get install nodejs
+```
 
-GOTO Common
+##Install the bot and dependencies
 
-## Linux Ubuntu 12.04
-
-`$ sudo apt-get update`
-
-`$sudo apt-get install g++ curl libssl-dev apache2-utils git-core make`
-
-`$ wget http://nodejs.org/dist/v0.8.14/node-v0.8.14.tar.gz`
-
-`$ tar xzvf node-v0.8.14.tar.gz`
-
-`$ cd node-v0.8.14`
-
-`$ ./configure`
-
-`$ make`
-
-`$ sudo make install`
-
-GOTO Common
-
-## Common
-`$ npm install js-yaml fs express irc async cron jade sqlite3`
+```
+$ cd path/to/standupbot
+$ npm install
+```

--- a/package.json
+++ b/package.json
@@ -5,20 +5,22 @@
   "version": "0.0.1",
   "private": "true",
   "dependencies": {
-    "async": "0.2.x",
+    "async": "1.4.2",
     "babel-eslint": "^4.1.2",
-    "cron": "1.0.x",
+    "body-parser": "1.12.3",
+    "cookie-parser": "1.3.5",
+    "cron": "1.0.9",
+    "express": "4.13.3",
     "eslint": "^1.4.1",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
-    "express": "3.2.x",
-    "irc": "0.3.x",
-    "jade": "0.31.x",
-    "js-yaml": "2.0.x",
-    "sqlite3": "^3.1.0"
+    "irc": "0.3.12",
+    "jade": "1.11.0",
+    "js-yaml": "3.4.2",
+    "sqlite3": "3.1.0"
   },
   "devDependencies": {
-    "mocha": "1.10.x"
+    "mocha": "2.3.2"
   },
   "scripts": {
     "start": "while(true) do node standupbot.js; sleep 5; done",

--- a/standupbot.js
+++ b/standupbot.js
@@ -10,6 +10,8 @@
 */
 
 // Imports
+var bodyParser = require('body-parser');
+var cookieParser = require('cookie-parser');
 var express = require('express');
 var fs = require('fs');
 var yaml = require('js-yaml');
@@ -69,9 +71,9 @@ app.set('view engine', 'jade');
 app.use('/static', express.static(__dirname + '/public'));
 
 // Enable web framework to parse HTTP params
-app.use(express.bodyParser());
+app.use(bodyParser.json({ extended: true }));
 // Enable cookie parsing on requests
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 // Serve up the root which includes the form
 app.get('/', function(req, res) {


### PR DESCRIPTION
The node ecosystem moves fast. The version of sqlite which is currently being used doesn't even work on node 0.12 which is what we've been developing timesync against.
