### PR TITLE
Fixed  typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To set up the SQLite database:
 
 # Usage
 
-Before using ``startupbot``, copy and modify its configuration:
+Before using ``standupbot``, copy and modify its configuration:
 
 ```
     $ cp conf/custom-config.yaml.dist conf/custom-config.yaml


### PR DESCRIPTION
Fixed typo in README where "standupbot" was referred to as "startupbot".
